### PR TITLE
refactor(util): extract common partition, swap, and shuffle logic

### DIFF
--- a/algo/src/main/java/org/example/algorithms/sorting/QuickSort.java
+++ b/algo/src/main/java/org/example/algorithms/sorting/QuickSort.java
@@ -1,5 +1,6 @@
 package org.example.algorithms.sorting;
 
+import org.example.algorithms.util.AlgoUtils;
 import org.example.metrics.Metrics;
 
 import java.util.Random;
@@ -25,7 +26,7 @@ public class QuickSort {
     private void quickSortLoop(int[] array, int left, int right, int depth, Metrics metrics) {
         while (left < right) {
             metrics.recordDepth(depth);
-            int pivotIndex = partition(array, left, right, metrics);
+            int pivotIndex = AlgoUtils.partition(array, left, right, random, metrics);
 
             if (pivotIndex - left < right - pivotIndex) {
                 quickSortLoop(array, left, pivotIndex - 1, depth + 1, metrics);
@@ -35,31 +36,5 @@ public class QuickSort {
                 right = pivotIndex - 1;
             }
         }
-    }
-
-    private int partition(int[] array, int left, int right, Metrics metrics) {
-        int pivotIndex = left + random.nextInt(right - left + 1);
-        int pivotValue = array[pivotIndex];
-        swap(array, pivotIndex, right, metrics);
-
-        int storeIndex = left;
-        for (int i = left; i < right; i++) {
-            metrics.incrementComparisons();
-            if (array[i] < pivotValue) {
-                swap(array, i, storeIndex, metrics);
-                storeIndex++;
-            }
-        }
-
-        swap(array, storeIndex, right, metrics);
-        return storeIndex;
-    }
-
-    private void swap(int[] array, int i, int j, Metrics metrics) {
-        if (i == j) return;
-        int temp = array[i];
-        array[i] = array[j];
-        array[j] = temp;
-        metrics.incrementSwaps();
     }
 }

--- a/algo/src/main/java/org/example/algorithms/util/AlgoUtils.java
+++ b/algo/src/main/java/org/example/algorithms/util/AlgoUtils.java
@@ -1,0 +1,49 @@
+package org.example.algorithms.util;
+
+import org.example.metrics.Metrics;
+
+import java.util.Random;
+
+public final class AlgoUtils {
+
+    private AlgoUtils() {
+        throw new UnsupportedOperationException("This is a utility class and cannot be instantiated");
+    }
+
+    public static void swap(int[] array, int i, int j, Metrics metrics) {
+        if (i == j) return;
+        int temp = array[i];
+        array[i] = array[j];
+        array[j] = temp;
+        if (metrics != null) {
+            metrics.incrementSwaps();
+        }
+    }
+
+    public static int partition(int[] array, int left, int right, Random random, Metrics metrics) {
+        int pivotIndex = left + random.nextInt(right - left + 1);
+        int pivotValue = array[pivotIndex];
+        swap(array, pivotIndex, right, metrics);
+
+        int storeIndex = left;
+        for (int i = left; i < right; i++) {
+            if (metrics != null) {
+                metrics.incrementComparisons();
+            }
+            if (array[i] < pivotValue) {
+                swap(array, i, storeIndex, metrics);
+                storeIndex++;
+            }
+        }
+
+        swap(array, storeIndex, right, metrics);
+        return storeIndex;
+    }
+
+    public static void shuffle(int[] array, Random random) {
+        for (int i = array.length - 1; i > 0; i--) {
+            int j = random.nextInt(i + 1);
+            swap(array, i, j, null);
+        }
+    }
+}


### PR DESCRIPTION
Common algorithm utilities like partition and swap are moved to a new AlgoUtils class. This removes code duplication from QuickSort and prepares for reuse in the upcoming Select algorithm. A Fisher-Yates shuffle utility is also added. Closes #5