### PR TITLE
feat(closest): implement divide-and-conquer closest pair algorithm

### DIFF
--- a/algo/src/main/java/org/example/algorithms/geometric/ClosestPair.java
+++ b/algo/src/main/java/org/example/algorithms/geometric/ClosestPair.java
@@ -1,0 +1,75 @@
+package org.example.algorithms.geometric;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+
+public class ClosestPair {
+
+    public PointPair findClosestPair(Point[] points) {
+        if (points == null || points.length < 2) {
+            return null;
+        }
+
+        Point[] pointsSortedByX = Arrays.copyOf(points, points.length);
+        Arrays.sort(pointsSortedByX, Comparator.comparingDouble(p -> p.x));
+
+        return findClosestPairRecursive(pointsSortedByX, 0, pointsSortedByX.length - 1);
+    }
+
+    private PointPair findClosestPairRecursive(Point[] pointsSortedByX, int left, int right) {
+        if (right - left < 3) {
+            return bruteForce(pointsSortedByX, left, right);
+        }
+
+        int mid = left + (right - left) / 2;
+        Point midPoint = pointsSortedByX[mid];
+
+        PointPair leftPair = findClosestPairRecursive(pointsSortedByX, left, mid);
+        PointPair rightPair = findClosestPairRecursive(pointsSortedByX, mid + 1, right);
+
+        PointPair minPair;
+        if (leftPair.distance < rightPair.distance) {
+            minPair = leftPair;
+        } else {
+            minPair = rightPair;
+        }
+
+        List<Point> strip = new ArrayList<>();
+        for (int i = left; i <= right; i++) {
+            if (Math.abs(pointsSortedByX[i].x - midPoint.x) < minPair.distance) {
+                strip.add(pointsSortedByX[i]);
+            }
+        }
+
+        strip.sort(Comparator.comparingDouble(p -> p.y));
+
+        for (int i = 0; i < strip.size(); i++) {
+            for (int j = i + 1; j < strip.size() && (strip.get(j).y - strip.get(i).y) < minPair.distance; j++) {
+                double dist = strip.get(i).distanceTo(strip.get(j));
+                if (dist < minPair.distance) {
+                    minPair = new PointPair(strip.get(i), strip.get(j));
+                }
+            }
+        }
+
+        return minPair;
+    }
+
+    private PointPair bruteForce(Point[] points, int left, int right) {
+        PointPair minPair = null;
+        double minDistance = Double.POSITIVE_INFINITY;
+
+        for (int i = left; i <= right; i++) {
+            for (int j = i + 1; j <= right; j++) {
+                double dist = points[i].distanceTo(points[j]);
+                if (dist < minDistance) {
+                    minDistance = dist;
+                    minPair = new PointPair(points[i], points[j]);
+                }
+            }
+        }
+        return minPair;
+    }
+}

--- a/algo/src/main/java/org/example/algorithms/geometric/Point.java
+++ b/algo/src/main/java/org/example/algorithms/geometric/Point.java
@@ -1,0 +1,22 @@
+package org.example.algorithms.geometric;
+
+public class Point {
+    public final double x;
+    public final double y;
+
+    public Point(double x, double y) {
+        this.x = x;
+        this.y = y;
+    }
+
+    public double distanceTo(Point other) {
+        double dx = this.x - other.x;
+        double dy = this.y - other.y;
+        return Math.sqrt(dx * dx + dy * dy);
+    }
+
+    @Override
+    public String toString() {
+        return "(" + x + ", " + y + ")";
+    }
+}

--- a/algo/src/main/java/org/example/algorithms/geometric/PointPair.java
+++ b/algo/src/main/java/org/example/algorithms/geometric/PointPair.java
@@ -1,0 +1,18 @@
+package org.example.algorithms.geometric;
+
+public class PointPair {
+    public final Point p1;
+    public final Point p2;
+    public final double distance;
+
+    public PointPair(Point p1, Point p2) {
+        this.p1 = p1;
+        this.p2 = p2;
+        this.distance = p1.distanceTo(p2);
+    }
+
+    @Override
+    public String toString() {
+        return "Pair: " + p1 + " and " + p2 + ", distance: " + distance;
+    }
+}

--- a/algo/src/test/java/org/example/algorithms/geometric/ClosestPairTest.java
+++ b/algo/src/test/java/org/example/algorithms/geometric/ClosestPairTest.java
@@ -1,0 +1,78 @@
+package org.example.algorithms.geometric;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+class ClosestPairTest {
+
+    private ClosestPair closestPair;
+
+    @BeforeEach
+    void setUp() {
+        closestPair = new ClosestPair();
+    }
+
+    @Test
+    void testEmptyAndSinglePoint() {
+        assertNull(closestPair.findClosestPair(new Point[]{}));
+        assertNull(closestPair.findClosestPair(new Point[]{new Point(1, 1)}));
+    }
+
+    @Test
+    void testSimpleCase() {
+        Point[] points = {
+                new Point(2, 3), new Point(12, 30),
+                new Point(40, 50), new Point(5, 1),
+                new Point(12, 10), new Point(3, 4)
+        };
+        PointPair result = closestPair.findClosestPair(points);
+        assertEquals(1.414, result.distance, 0.001);
+    }
+
+    @Test
+    void testCollinearPoints() {
+        Point[] points = {new Point(0, 0), new Point(0, 1), new Point(0, 5), new Point(0, 10)};
+        PointPair result = closestPair.findClosestPair(points);
+        assertEquals(1.0, result.distance, 0.001);
+    }
+
+    @Test
+    void testWithBruteForce() {
+        for (int i = 0; i < 50; i++) {
+            Point[] points = generateRandomPoints(100, 1000);
+            PointPair fastResult = closestPair.findClosestPair(points);
+            PointPair bruteForceResult = bruteForce(points);
+            assertEquals(bruteForceResult.distance, fastResult.distance, 0.00001);
+        }
+    }
+
+    private Point[] generateRandomPoints(int numPoints, int maxCoord) {
+        Random rand = new Random();
+        Point[] points = new Point[numPoints];
+        for (int i = 0; i < numPoints; i++) {
+            points[i] = new Point(rand.nextDouble() * maxCoord, rand.nextDouble() * maxCoord);
+        }
+        return points;
+    }
+
+    private PointPair bruteForce(Point[] points) {
+        if (points == null || points.length < 2) return null;
+        PointPair minPair = null;
+        double minDistance = Double.POSITIVE_INFINITY;
+        for (int i = 0; i < points.length; i++) {
+            for (int j = i + 1; j < points.length; j++) {
+                double dist = points[i].distanceTo(points[j]);
+                if (dist < minDistance) {
+                    minDistance = dist;
+                    minPair = new PointPair(points[i], points[j]);
+                }
+            }
+        }
+        return minPair;
+    }
+}


### PR DESCRIPTION
Adds an O(n log n) algorithm for the closest pair of points problem. The implementation uses a divide-and-conquer strategy, including the critical strip-check step. Unit tests validate correctness against a brute-force O(n^2) approach. Closes #7