### PR TITLE
bench(jmh): create benchmark harness for select vs sort

### DIFF
--- a/algo/pom.xml
+++ b/algo/pom.xml
@@ -34,6 +34,17 @@
       <artifactId>picocli</artifactId>
       <version>4.7.5</version>
     </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-core</artifactId>
+      <version>1.37</version>
+    </dependency>
+    <dependency>
+      <groupId>org.openjdk.jmh</groupId>
+      <artifactId>jmh-generator-annprocess</artifactId>
+      <version>1.37</version>
+      <scope>provided</scope>
+    </dependency>
   </dependencies>
 
 
@@ -46,6 +57,27 @@
         <configuration>
           <useModulePath>false</useModulePath>
         </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-shade-plugin</artifactId>
+        <version>3.5.1</version>
+        <executions>
+          <execution>
+            <phase>package</phase>
+            <goals>
+              <goal>shade</goal>
+            </goals>
+            <configuration>
+              <finalName>benchmarks</finalName>
+              <transformers>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <mainClass>org.openjdk.jmh.Main</mainClass>
+                </transformer>
+              </transformers>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
     </plugins>
   </build>

--- a/algo/src/main/java/org/example/benchmarks/SelectVsSortBenchmark.java
+++ b/algo/src/main/java/org/example/benchmarks/SelectVsSortBenchmark.java
@@ -1,0 +1,54 @@
+package org.example.benchmarks;
+
+import org.example.algorithms.selection.DeterministicSelect;
+import org.openjdk.jmh.annotations.*;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+import java.util.Arrays;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MICROSECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 5, time = 1)
+public class SelectVsSortBenchmark {
+
+    @Param({"1000", "10000", "100000"})
+    private int n;
+
+    private int[] sourceArray;
+    private int k;
+    private DeterministicSelect deterministicSelect;
+
+    @Setup
+    public void setup() {
+        sourceArray = new Random().ints(n, -n, n).toArray();
+        k = n / 2;
+        deterministicSelect = new DeterministicSelect();
+    }
+
+    @Benchmark
+    public int benchmarkSelect() {
+        return deterministicSelect.select(sourceArray.clone(), k);
+    }
+
+    @Benchmark
+    public int benchmarkSortAndGet() {
+        int[] cloned = sourceArray.clone();
+        Arrays.sort(cloned);
+        return cloned[k - 1];
+    }
+
+    public static void main(String[] args) throws RunnerException {
+        Options opt = new OptionsBuilder()
+                .include(SelectVsSortBenchmark.class.getSimpleName())
+                .build();
+        new Runner(opt).run();
+    }
+}


### PR DESCRIPTION
Adds a JMH benchmark to compare the performance of DeterministicSelect (O(n)) against the baseline approach of sorting the array and picking the k-th element (O(n log n)). The benchmark is configured to run for various input sizes. Closes #9